### PR TITLE
Handle double-quotes in JS/TS imports

### DIFF
--- a/emerge/languages/javascriptparser.py
+++ b/emerge/languages/javascriptparser.py
@@ -120,7 +120,7 @@ class JavaScriptParser(AbstractParser, AbstractParsingCore):
                 valid_name = pp.Word(pp.alphanums + CoreParsingKeyword.AT.value + CoreParsingKeyword.DOT.value + CoreParsingKeyword.ASTERISK.value +
                                      CoreParsingKeyword.UNDERSCORE.value + CoreParsingKeyword.DASH.value + CoreParsingKeyword.SLASH.value)
                 expression_to_match = pp.SkipTo(pp.Literal(JavaScriptParsingKeyword.FROM.value)) + pp.Literal(JavaScriptParsingKeyword.FROM.value) + \
-                    pp.Suppress(pp.Literal(CoreParsingKeyword.SINGLE_QUOTE.value)) + \
+                    pp.OneOrMore(pp.Suppress(pp.Literal(CoreParsingKeyword.SINGLE_QUOTE.value)) | pp.Suppress(pp.Literal(CoreParsingKeyword.DOUBLE_QUOTE.value))) + \
                     pp.FollowedBy(pp.OneOrMore(valid_name.setResultsName(CoreParsingKeyword.IMPORT_ENTITY_NAME.value)))
 
                 try:

--- a/emerge/languages/typescriptparser.py
+++ b/emerge/languages/typescriptparser.py
@@ -120,7 +120,7 @@ class TypeScriptParser(AbstractParser, AbstractParsingCore):
                 valid_name = pp.Word(pp.alphanums + CoreParsingKeyword.AT.value + CoreParsingKeyword.DOT.value + CoreParsingKeyword.ASTERISK.value +
                                      CoreParsingKeyword.UNDERSCORE.value + CoreParsingKeyword.DASH.value + CoreParsingKeyword.SLASH.value)
                 expression_to_match = pp.SkipTo(pp.Literal(TypeScriptParsingKeyword.FROM.value)) + pp.Literal(TypeScriptParsingKeyword.FROM.value) + \
-                    pp.Suppress(pp.Literal(CoreParsingKeyword.SINGLE_QUOTE.value)) + \
+                    pp.OneOrMore(pp.Suppress(pp.Literal(CoreParsingKeyword.SINGLE_QUOTE.value)) | pp.Suppress(pp.Literal(CoreParsingKeyword.DOUBLE_QUOTE.value))) + \
                     pp.FollowedBy(pp.OneOrMore(valid_name.setResultsName(CoreParsingKeyword.IMPORT_ENTITY_NAME.value)))
 
                 try:

--- a/tests/parsers/test_javascript_parser.py
+++ b/tests/parsers/test_javascript_parser.py
@@ -39,7 +39,7 @@ class JavaScriptParserTestCase(unittest.TestCase):
 
         results: Dict[str, FileResult] = self.parser.results
         self.assertTrue(results)
-        self.assertTrue(len(results) == 2)
+        self.assertTrue(len(results) == 3)
 
         result: FileResult
         for _, result in results.items():

--- a/tests/testdata/javascript.py
+++ b/tests/testdata/javascript.py
@@ -351,4 +351,11 @@ export function launchEditor(
     childProcess = null;
   });
 }
+""", "file3.js": """
+// Test parser also works with double-quote imports
+import {sum} from "./math";
+
+export function add10(a) {
+  return sum(a, 10);
+}
 """}

--- a/tests/testdata/typescript.py
+++ b/tests/testdata/typescript.py
@@ -99,4 +99,11 @@ function sortActivatedRouteSnapshots(nodes: TreeNode<ActivatedRouteSnapshot>[]):
     return a.value.outlet.localeCompare(b.value.outlet);
   });
 }
+""", "file3.ts": """
+// Test parser also works with double-quote imports
+import {sum} from "./math";
+
+export function add10(a: number): number {
+  return sum(a, 10);
+}
 """}


### PR DESCRIPTION
I noticed that only single-quotes were parsed, so this valid code wouldn't generate the appropriate fan-in/fan-out dependencies:

```js
import {sum, multiply} from "./math";

// rest of the code
```

This PR implements the double-quote as an alternative valid symbol for imports in JS and TS.
I added another "file" in JS tests to prove that it works—the test failed without the implementation change.

Next up I plan to handle the `require()` format of imports for JS and TS. Basically, this is valid node.js code:

```
var {sum, multiply} = require("./math");

// rest of the code
```

But it's not properly parsed yet. I have a POC that works, I need to clean it up. But first, I'd like to get your feedback on this change to make sure I'm heading in the correct direction with this.

Thank you!