### PR TITLE
Parse require-style imports for JS & TS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,12 +14,12 @@ and get it running as a standalone tool (see [README](README.md) for a step by s
 
 ## The following code style/convention/tooling details currently exist for this project.
 
+- The code style in this project is based on the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guide for python code, with a minimal customization of those rules for pylint.
+
 - This project uses [pylint](https://pypi.org/project/pylint/) with the following rule modification
 ```
 pylint --msg-template "{path}:{line}:{column}:{category}:{symbol} - {msg}" --disable=all --enable=F,E,unneeded-not,invalid-name,unidiomatic-typecheck,too-many-lines,multiple-imports,comparison-with-itself,cyclic-import,too-many-ancestors,too-many-branches,too-many-statements,too-many-nested-blocks,consider-using-join,bad-classmethod-argument,unused-argument,protected-access,abstract-method,unreachable,duplicate-key,unnecessary-semicolon,global-variable-not-assigned,unused-variable,binary-op-exception,bad-format-string,anomalous-backslash-in-string,bad-open-mode emerge 
 ```
-
-- The code style in this project is based on the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guide for python code, with a minimal customization of those rules for pylint (details in -> Contributing.md)
 
 - [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) is used in this project, but (unfortunately) with type checking mode off, the basic mode is a point in the future roadmap
 - Docstring coverage is measured with [interrogate](https://pypi.org/project/interrogate/) and is about 25% for the first public release

--- a/emerge/languages/javascriptparser.py
+++ b/emerge/languages/javascriptparser.py
@@ -27,6 +27,7 @@ coloredlogs.install(level='E', logger=LOGGER.logger(), fmt=Logger.log_format)
 class JavaScriptParsingKeyword(Enum):
     IMPORT = "import"
     FROM = "from"
+    REQUIRE = "require"
     OPEN_SCOPE = "{"
     CLOSE_SCOPE = "}"
     INLINE_COMMENT = "//"
@@ -120,6 +121,65 @@ class JavaScriptParser(AbstractParser, AbstractParsingCore):
                 valid_name = pp.Word(pp.alphanums + CoreParsingKeyword.AT.value + CoreParsingKeyword.DOT.value + CoreParsingKeyword.ASTERISK.value +
                                      CoreParsingKeyword.UNDERSCORE.value + CoreParsingKeyword.DASH.value + CoreParsingKeyword.SLASH.value)
                 expression_to_match = pp.SkipTo(pp.Literal(JavaScriptParsingKeyword.FROM.value)) + pp.Literal(JavaScriptParsingKeyword.FROM.value) + \
+                    pp.OneOrMore(pp.Suppress(pp.Literal(CoreParsingKeyword.SINGLE_QUOTE.value)) | pp.Suppress(pp.Literal(CoreParsingKeyword.DOUBLE_QUOTE.value))) + \
+                    pp.FollowedBy(pp.OneOrMore(valid_name.setResultsName(CoreParsingKeyword.IMPORT_ENTITY_NAME.value)))
+
+                try:
+                    # try to parse the dependency based on the syntax
+                    parsing_result = expression_to_match.parseString(read_ahead_string)
+                except Exception as some_exception:
+                    result.analysis.statistics.increment(Statistics.Key.PARSING_MISSES)
+                    LOGGER.warning(f'warning: could not parse result {result=}\n{some_exception}')
+                    LOGGER.warning(f'next tokens: {[obj] + following[:AbstractParsingCore.Constants.MAX_DEBUG_TOKENS_READAHEAD.value]}')
+                    continue
+
+                analysis.statistics.increment(Statistics.Key.PARSING_HITS)
+
+                dependency = getattr(parsing_result, CoreParsingKeyword.IMPORT_ENTITY_NAME.value)
+                if CoreParsingKeyword.AT.value in dependency:
+                    pass  # let @-dependencies as they are
+                elif dependency.count(CoreParsingKeyword.POSIX_CURRENT_DIRECTORY.value) == 1 and CoreParsingKeyword.POSIX_PARENT_DIRECTORY.value not in dependency:  # e.g. ./foo
+                    dependency = dependency.replace(CoreParsingKeyword.POSIX_CURRENT_DIRECTORY.value, '')
+
+                elif CoreParsingKeyword.POSIX_PARENT_DIRECTORY.value in dependency:  # e.g. '../../foo.js': a naive way to get a good/unique dependency path ...
+                    # ... first construct the result path + dependency path
+                    path = result.absolute_name.replace(os.path.basename(os.path.normpath(result.scanned_file_name)), "")
+                    path += dependency
+                    posix_path = PosixPath(path)
+                    try:
+                        # then resolve the full path in a posix way
+                        resolved_posix_path = posix_path.resolve()
+                        project_scanning_path = analysis.source_directory
+                        if project_scanning_path[-1] != CoreParsingKeyword.SLASH.value:
+                            project_scanning_path = f"{project_scanning_path}{CoreParsingKeyword.SLASH.value}"
+
+                        if project_scanning_path in str(resolved_posix_path):
+                            # substract the beginning project source path
+                            resolved_relative_path = str(resolved_posix_path).replace(f"{analysis.source_directory}{CoreParsingKeyword.SLASH.value}", "")
+                            # set our new constructed dependency
+                            dependency = resolved_relative_path
+                    except:
+                        pass
+
+                # strongly assume the .js suffix for every dependency
+                if '.js' not in dependency:
+                    dependency = f"{dependency}.js"
+
+                # ignore any dependency substring from the config ignore list
+                if self._is_dependency_in_ignore_list(dependency, analysis):
+                    LOGGER.debug(f'ignoring dependency from {result.unique_name} to {dependency}')
+                else:
+                    result.scanned_import_dependencies.append(dependency)
+                    LOGGER.debug(f'adding import: {dependency} to {result.unique_name}')
+
+            elif obj == JavaScriptParsingKeyword.REQUIRE.value:
+                read_ahead_string = self.create_read_ahead_string(obj, following)
+
+                # grammar syntax for pyparsing to parse dependencies
+                valid_name = pp.Word(pp.alphanums + CoreParsingKeyword.AT.value + CoreParsingKeyword.DOT.value + CoreParsingKeyword.ASTERISK.value +
+                                     CoreParsingKeyword.UNDERSCORE.value + CoreParsingKeyword.DASH.value + CoreParsingKeyword.SLASH.value)
+                expression_to_match = pp.SkipTo(pp.Literal(CoreParsingKeyword.OPENING_ROUND_BRACKET.value)) + \
+                    pp.Literal(CoreParsingKeyword.OPENING_ROUND_BRACKET.value) + \
                     pp.OneOrMore(pp.Suppress(pp.Literal(CoreParsingKeyword.SINGLE_QUOTE.value)) | pp.Suppress(pp.Literal(CoreParsingKeyword.DOUBLE_QUOTE.value))) + \
                     pp.FollowedBy(pp.OneOrMore(valid_name.setResultsName(CoreParsingKeyword.IMPORT_ENTITY_NAME.value)))
 

--- a/emerge/languages/typescriptparser.py
+++ b/emerge/languages/typescriptparser.py
@@ -113,6 +113,9 @@ class TypeScriptParser(AbstractParser, AbstractParsingCore):
         filtered_list_no_comments = self.preprocess_file_content_and_generate_token_list_by_mapping(source_string_no_comments, self._token_mappings)
 
         for _, obj, following in self._gen_word_read_ahead(filtered_list_no_comments):
+            if obj != TypeScriptParsingKeyword.IMPORT.value:
+                continue
+
             if obj == TypeScriptParsingKeyword.IMPORT.value:
                 read_ahead_string = self.create_read_ahead_string(obj, following)
 

--- a/emerge/languages/typescriptparser.py
+++ b/emerge/languages/typescriptparser.py
@@ -117,65 +117,66 @@ class TypeScriptParser(AbstractParser, AbstractParsingCore):
             if obj != TypeScriptParsingKeyword.IMPORT.value and obj != TypeScriptParsingKeyword.REQUIRE.value:
                 continue
 
-            if obj == TypeScriptParsingKeyword.IMPORT.value:
-                read_ahead_string = self.create_read_ahead_string(obj, following)
+            read_ahead_string = self.create_read_ahead_string(obj, following)
 
-                # grammar syntax for pyparsing to parse dependencies
-                valid_name = pp.Word(pp.alphanums + CoreParsingKeyword.AT.value + CoreParsingKeyword.DOT.value + CoreParsingKeyword.ASTERISK.value +
-                                     CoreParsingKeyword.UNDERSCORE.value + CoreParsingKeyword.DASH.value + CoreParsingKeyword.SLASH.value)
+            # grammar syntax for pyparsing to parse dependencies
+            valid_name = pp.Word(pp.alphanums + CoreParsingKeyword.AT.value + CoreParsingKeyword.DOT.value + CoreParsingKeyword.ASTERISK.value +
+                                    CoreParsingKeyword.UNDERSCORE.value + CoreParsingKeyword.DASH.value + CoreParsingKeyword.SLASH.value)
+
+            if obj == TypeScriptParsingKeyword.IMPORT.value:
                 expression_to_match = pp.SkipTo(pp.Literal(TypeScriptParsingKeyword.FROM.value)) + pp.Literal(TypeScriptParsingKeyword.FROM.value) + \
                     pp.OneOrMore(pp.Suppress(pp.Literal(CoreParsingKeyword.SINGLE_QUOTE.value)) | pp.Suppress(pp.Literal(CoreParsingKeyword.DOUBLE_QUOTE.value))) + \
                     pp.FollowedBy(pp.OneOrMore(valid_name.setResultsName(CoreParsingKeyword.IMPORT_ENTITY_NAME.value)))
 
+            try:
+                # try to parse the dependency based on the syntax
+                parsing_result = expression_to_match.parseString(read_ahead_string)
+            except Exception as some_exception:
+                result.analysis.statistics.increment(Statistics.Key.PARSING_MISSES)
+                LOGGER.warning(f'warning: could not parse result {result=}\n{some_exception}')
+                LOGGER.warning(f'next tokens: {[obj] + following[:AbstractParsingCore.Constants.MAX_DEBUG_TOKENS_READAHEAD.value]}')
+                continue
+
+            analysis.statistics.increment(Statistics.Key.PARSING_HITS)
+
+            dependency = getattr(parsing_result, CoreParsingKeyword.IMPORT_ENTITY_NAME.value)
+            if CoreParsingKeyword.AT.value in dependency:
+                pass  # let @-dependencies as they are
+            elif dependency.count(CoreParsingKeyword.POSIX_CURRENT_DIRECTORY.value) == 1 and CoreParsingKeyword.POSIX_PARENT_DIRECTORY.value not in dependency:  # e.g. ./foo
+                dependency = dependency.replace(CoreParsingKeyword.POSIX_CURRENT_DIRECTORY.value, '')
+                if '.ts' not in dependency:
+                    dependency = f"{dependency}.ts"
+            elif CoreParsingKeyword.POSIX_PARENT_DIRECTORY.value in dependency:  # e.g. '../../foo.ts': a naive way to get a good/unique dependency path ...
+
+                # ... first construct the result path + dependency path
+                path = result.absolute_name.replace(os.path.basename(os.path.normpath(result.scanned_file_name)), "")
+                path += dependency
+                posix_path = PosixPath(path)
                 try:
-                    # try to parse the dependency based on the syntax
-                    parsing_result = expression_to_match.parseString(read_ahead_string)
-                except Exception as some_exception:
-                    result.analysis.statistics.increment(Statistics.Key.PARSING_MISSES)
-                    LOGGER.warning(f'warning: could not parse result {result=}\n{some_exception}')
-                    LOGGER.warning(f'next tokens: {[obj] + following[:AbstractParsingCore.Constants.MAX_DEBUG_TOKENS_READAHEAD.value]}')
-                    continue
+                    # then resolve the full path in a posix way
+                    resolved_posix_path = posix_path.resolve()
 
-                analysis.statistics.increment(Statistics.Key.PARSING_HITS)
+                    project_scanning_path = analysis.source_directory
+                    if project_scanning_path[-1] != CoreParsingKeyword.SLASH.value:
+                        project_scanning_path = f"{project_scanning_path}{CoreParsingKeyword.SLASH.value}"
 
-                dependency = getattr(parsing_result, CoreParsingKeyword.IMPORT_ENTITY_NAME.value)
-                if CoreParsingKeyword.AT.value in dependency:
-                    pass  # let @-dependencies as they are
-                elif dependency.count(CoreParsingKeyword.POSIX_CURRENT_DIRECTORY.value) == 1 and CoreParsingKeyword.POSIX_PARENT_DIRECTORY.value not in dependency:  # e.g. ./foo
-                    dependency = dependency.replace(CoreParsingKeyword.POSIX_CURRENT_DIRECTORY.value, '')
-                    if '.ts' not in dependency:
-                        dependency = f"{dependency}.ts"
-                elif CoreParsingKeyword.POSIX_PARENT_DIRECTORY.value in dependency:  # e.g. '../../foo.ts': a naive way to get a good/unique dependency path ...
+                    if project_scanning_path in str(resolved_posix_path):
+                        # substract the beginning project source path
+                        resolved_relative_path = str(resolved_posix_path).replace(f"{analysis.source_directory}{CoreParsingKeyword.SLASH.value}", "")
+                        if '.ts' not in resolved_relative_path:
+                            # assume the dependency is a ts file
+                            resolved_relative_path = f"{resolved_relative_path}.ts"
+                        # set our new constructed dependency
+                        dependency = resolved_relative_path
+                except:
+                    pass
 
-                    # ... first construct the result path + dependency path
-                    path = result.absolute_name.replace(os.path.basename(os.path.normpath(result.scanned_file_name)), "")
-                    path += dependency
-                    posix_path = PosixPath(path)
-                    try:
-                        # then resolve the full path in a posix way
-                        resolved_posix_path = posix_path.resolve()
-
-                        project_scanning_path = analysis.source_directory
-                        if project_scanning_path[-1] != CoreParsingKeyword.SLASH.value:
-                            project_scanning_path = f"{project_scanning_path}{CoreParsingKeyword.SLASH.value}"
-
-                        if project_scanning_path in str(resolved_posix_path):
-                            # substract the beginning project source path
-                            resolved_relative_path = str(resolved_posix_path).replace(f"{analysis.source_directory}{CoreParsingKeyword.SLASH.value}", "")
-                            if '.ts' not in resolved_relative_path:
-                                # assume the dependency is a ts file
-                                resolved_relative_path = f"{resolved_relative_path}.ts"
-                            # set our new constructed dependency
-                            dependency = resolved_relative_path
-                    except:
-                        pass
-
-                # ignore any dependency substring from the config ignore list
-                if self._is_dependency_in_ignore_list(dependency, analysis):
-                    LOGGER.debug(f'ignoring dependency from {result.unique_name} to {dependency}')
-                else:
-                    result.scanned_import_dependencies.append(dependency)
-                    LOGGER.debug(f'adding import: {dependency} to {result.unique_name}')
+            # ignore any dependency substring from the config ignore list
+            if self._is_dependency_in_ignore_list(dependency, analysis):
+                LOGGER.debug(f'ignoring dependency from {result.unique_name} to {dependency}')
+            else:
+                result.scanned_import_dependencies.append(dependency)
+                LOGGER.debug(f'adding import: {dependency} to {result.unique_name}')
 
     # pylint: disable=unused-argument
     def _add_package_name_to_result(self, result: AbstractResult) -> str:

--- a/emerge/languages/typescriptparser.py
+++ b/emerge/languages/typescriptparser.py
@@ -27,6 +27,7 @@ coloredlogs.install(level='E', logger=LOGGER.logger(), fmt=Logger.log_format)
 class TypeScriptParsingKeyword(Enum):
     IMPORT = "import"
     FROM = "from"
+    REQUIRE = "require"
     OPEN_SCOPE = "{"
     CLOSE_SCOPE = "}"
     INLINE_COMMENT = "//"
@@ -113,7 +114,7 @@ class TypeScriptParser(AbstractParser, AbstractParsingCore):
         filtered_list_no_comments = self.preprocess_file_content_and_generate_token_list_by_mapping(source_string_no_comments, self._token_mappings)
 
         for _, obj, following in self._gen_word_read_ahead(filtered_list_no_comments):
-            if obj != TypeScriptParsingKeyword.IMPORT.value:
+            if obj != TypeScriptParsingKeyword.IMPORT.value and obj != TypeScriptParsingKeyword.REQUIRE.value:
                 continue
 
             if obj == TypeScriptParsingKeyword.IMPORT.value:

--- a/emerge/languages/typescriptparser.py
+++ b/emerge/languages/typescriptparser.py
@@ -1,5 +1,5 @@
 """
-Contains the implementation of the JavaScript language parser and a relevant keyword enum. This is basically a copy of the JavaScript parser with some nice modifications.
+Contains the implementation of the TypeScript language parser and a relevant keyword enum. This is basically a copy of the JavaScript parser with some nice modifications.
 """
 
 # Authors: Grzegorz Lato <grzegorz.lato@gmail.com>

--- a/emerge/languages/typescriptparser.py
+++ b/emerge/languages/typescriptparser.py
@@ -127,6 +127,11 @@ class TypeScriptParser(AbstractParser, AbstractParsingCore):
                 expression_to_match = pp.SkipTo(pp.Literal(TypeScriptParsingKeyword.FROM.value)) + pp.Literal(TypeScriptParsingKeyword.FROM.value) + \
                     pp.OneOrMore(pp.Suppress(pp.Literal(CoreParsingKeyword.SINGLE_QUOTE.value)) | pp.Suppress(pp.Literal(CoreParsingKeyword.DOUBLE_QUOTE.value))) + \
                     pp.FollowedBy(pp.OneOrMore(valid_name.setResultsName(CoreParsingKeyword.IMPORT_ENTITY_NAME.value)))
+            elif obj == TypeScriptParsingKeyword.REQUIRE.value:
+                expression_to_match = pp.SkipTo(pp.Literal(CoreParsingKeyword.OPENING_ROUND_BRACKET.value)) + \
+                    pp.Literal(CoreParsingKeyword.OPENING_ROUND_BRACKET.value) + \
+                    pp.OneOrMore(pp.Suppress(pp.Literal(CoreParsingKeyword.SINGLE_QUOTE.value)) | pp.Suppress(pp.Literal(CoreParsingKeyword.DOUBLE_QUOTE.value))) + \
+                    pp.FollowedBy(pp.OneOrMore(valid_name.setResultsName(CoreParsingKeyword.IMPORT_ENTITY_NAME.value)))
 
             try:
                 # try to parse the dependency based on the syntax

--- a/tests/parsers/test_javascript_parser.py
+++ b/tests/parsers/test_javascript_parser.py
@@ -39,7 +39,7 @@ class JavaScriptParserTestCase(unittest.TestCase):
 
         results: Dict[str, FileResult] = self.parser.results
         self.assertTrue(results)
-        self.assertTrue(len(results) == 3)
+        self.assertTrue(len(results) == 4)
 
         result: FileResult
         for _, result in results.items():

--- a/tests/parsers/test_javascript_parser.py
+++ b/tests/parsers/test_javascript_parser.py
@@ -1,5 +1,5 @@
 """
-All unit tests that are related to JavaParser.
+All unit tests that are related to JavaScriptParser.
 """
 
 # Authors: Grzegorz Lato <grzegorz.lato@gmail.com>

--- a/tests/parsers/test_typescript_parser.py
+++ b/tests/parsers/test_typescript_parser.py
@@ -39,7 +39,7 @@ class TypeScriptParserTestCase(unittest.TestCase):
 
         results: Dict[str, FileResult] = self.parser.results
         self.assertTrue(results)
-        self.assertTrue(len(results) == 3)
+        self.assertTrue(len(results) == 4)
 
         result: FileResult
         for _, result in results.items():

--- a/tests/parsers/test_typescript_parser.py
+++ b/tests/parsers/test_typescript_parser.py
@@ -1,0 +1,53 @@
+"""
+All unit tests that are related to TypeScriptParser.
+"""
+
+# Authors: Grzegorz Lato <grzegorz.lato@gmail.com>
+# License: MIT
+
+import unittest
+from emerge.languages.typescriptparser import TypeScriptParser
+from emerge.results import FileResult
+from emerge.languages.abstractparser import LanguageType
+from emerge.analysis import Analysis
+from tests.testdata.typescript import TYPESCRIPT_TEST_FILES
+from typing import Dict
+import coloredlogs
+import logging
+
+LOGGER = logging.getLogger('TESTS')
+coloredlogs.install(level='INFO', logger=LOGGER, fmt='\n%(asctime)s %(name)s %(levelname)s %(message)s')
+
+
+class TypeScriptParserTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.example_data = TYPESCRIPT_TEST_FILES
+        self.parser = TypeScriptParser()
+        self.analysis = Analysis()
+        self.analysis.analysis_name = "test"
+
+    def tearDown(self):
+        pass
+
+    def test_generate_file_results(self):
+        """Generate file results for all parsers and check if metrics were calculated."""
+        self.assertFalse(self.parser.results)
+
+        for file_name, file_content in self.example_data.items():
+            self.parser.generate_file_result_from_analysis(self.analysis, file_name=file_name, full_file_path="/tests/" + file_name, file_content=file_content)
+
+        results: Dict[str, FileResult] = self.parser.results
+        self.assertTrue(results)
+        self.assertTrue(len(results) == 3)
+
+        result: FileResult
+        for _, result in results.items():
+            self.assertTrue(len(result.scanned_tokens) > 0)
+            self.assertTrue(len(result.scanned_import_dependencies) > 0)
+
+            self.assertTrue(result.analysis.analysis_name.strip())
+            self.assertTrue(result.scanned_file_name.strip())
+            self.assertTrue(result.scanned_by.strip())
+            self.assertTrue(result.scanned_language == LanguageType.TYPESCRIPT)
+        LOGGER.info(f'test successful')

--- a/tests/testdata/javascript.py
+++ b/tests/testdata/javascript.py
@@ -358,4 +358,26 @@ import {sum} from "./math";
 export function add10(a) {
   return sum(a, 10);
 }
+""", "file4.js": """
+// Test parser also works with require-style imports
+var Reflux = require("./lib/reflux");
+var urlb = require('../lib/urlb');
+
+function search(info, offset) {
+  var url = urlb("/api/transaction-error-mappings", {
+    code: info.code,
+    message: info.message,
+    operation: info.operation,
+    unmapped: info.unmapped,
+    offset: offset || 0,
+    limit: 20
+  });
+
+  request.apiRequest("get", url, this.trigger.bind(this, "search"));
+}
+
+module.exports = {
+  search,
+  purchaseSearch: Reflux.createAction()
+}
 """}

--- a/tests/testdata/typescript.py
+++ b/tests/testdata/typescript.py
@@ -106,4 +106,30 @@ import {sum} from "./math";
 export function add10(a: number): number {
   return sum(a, 10);
 }
+""", "file4.ts": """
+// Test parser also works with require-style imports
+var Reflux = require("./lib/reflux");
+var urlb = require('../lib/urlb');
+
+export function search(info: Info, offset: number) {
+  var url = urlb("/api/transaction-error-mappings", {
+    code: info.code,
+    message: info.message,
+    operation: info.operation,
+    unmapped: info.unmapped,
+    offset: offset || 0,
+    limit: 20
+  });
+
+  request.apiRequest("get", url, this.trigger.bind(this, "search"));
+}
+
+interface Info {
+  code: number;
+  message: string;
+  operation: string;
+  unmapped: boolean;
+}
+
+export const purchaseSearch = Reflux.createAction();
 """}


### PR DESCRIPTION
As discussed, I finally adapted the parsers to handle the `require()` imports.

I added tests to show it's working fine. I also added TS tests that were missing (a duplicate from JS ones at this point).