### PR TITLE
[FIX] Security - useing Safeloader

### DIFF
--- a/emerge/config.py
+++ b/emerge/config.py
@@ -549,13 +549,13 @@ class YamlLoader:
 
     def _load_yaml_from_config_file_content(self):
         try:
-            self._yaml = yaml.load(self._config_file_content, Loader=yaml.FullLoader)
+            self._yaml = yaml.load(self._config_file_content, Loader=yaml.SafeLoader)
         except yaml.YAMLError as exc:
             LOGGER.error(exc)
 
     def _load_yaml_from_schema_file_content(self):
         try:
-            self._schema = yaml.load(self._schema_file_content, Loader=yaml.FullLoader)
+            self._schema = yaml.load(self._schema_file_content, Loader=yaml.SafeLoader)
         except yaml.YAMLError as exc:
             LOGGER.error(exc)
 


### PR DESCRIPTION
using SafeLoader instead of FullLoader to avoid security risks while loading yaml files

here is a example exploit (poc) :

![poc](https://user-images.githubusercontent.com/36979660/136093689-a594e9ec-e441-4247-b4f2-c6c6bf3c9e71.png) 

\

hacktoberfest