### PR TITLE
Add support for swift `protocol`, `enum`, `let`

### DIFF
--- a/emerge/languages/swiftparser.py
+++ b/emerge/languages/swiftparser.py
@@ -28,7 +28,10 @@ coloredlogs.install(level='E', logger=LOGGER.logger(), fmt=Logger.log_format)
 class SwiftParsingKeyword(Enum):
     CLASS = "class"
     STRUCT = "struct"
+    PROTOCOL = "protocol"
+    ENUM = "enum"
     VAR = "var"
+    LET = "let"
     FUNC = "func"
     EXTENSION = "extension"
     OPEN_SCOPE = "{"
@@ -95,11 +98,11 @@ class SwiftParser(AbstractParser, ParsingMixin):
         result: FileResult
         for _, result in filtered_results.items():
 
-            entity_keywords: List[str] = [SwiftParsingKeyword.CLASS.value, SwiftParsingKeyword.STRUCT.value]
+            entity_keywords: List[str] = [SwiftParsingKeyword.CLASS.value, SwiftParsingKeyword.STRUCT.value, SwiftParsingKeyword.ENUM.value, SwiftParsingKeyword.PROTOCOL.value]
             entity_name = pp.Word(pp.alphanums)
 
-            match_expression = (pp.Keyword(SwiftParsingKeyword.CLASS.value) | pp.Keyword(SwiftParsingKeyword.STRUCT.value)) + \
-                (~pp.Keyword(SwiftParsingKeyword.VAR.value) & ~pp.Keyword(SwiftParsingKeyword.FUNC.value)) + \
+            match_expression = (pp.Keyword(SwiftParsingKeyword.CLASS.value) | pp.Keyword(SwiftParsingKeyword.STRUCT.value) | pp.Keyword(SwiftParsingKeyword.ENUM.value) | pp.Keyword(SwiftParsingKeyword.PROTOCOL.value)) + \
+                (~pp.Keyword(SwiftParsingKeyword.LET.value) & ~pp.Keyword(SwiftParsingKeyword.VAR.value) & ~pp.Keyword(SwiftParsingKeyword.FUNC.value)) + \
                 entity_name.setResultsName(CoreParsingKeyword.ENTITY_NAME.value) + \
                 pp.Optional(pp.Keyword(CoreParsingKeyword.COLON.value)) + pp.SkipTo(pp.FollowedBy(SwiftParsingKeyword.OPEN_SCOPE.value))
 
@@ -177,11 +180,11 @@ class SwiftParser(AbstractParser, ParsingMixin):
         result: FileResult
         for _, result in filtered_results.items():
 
-            entity_keywords: List[str] = [SwiftParsingKeyword.CLASS.value, SwiftParsingKeyword.STRUCT.value]
+            entity_keywords: List[str] = [SwiftParsingKeyword.CLASS.value, SwiftParsingKeyword.STRUCT.value, SwiftParsingKeyword.ENUM.value, SwiftParsingKeyword.PROTOCOL.value]
             entity_name = pp.Word(pp.alphanums)
 
-            match_expression = (pp.Keyword(SwiftParsingKeyword.CLASS.value) | pp.Keyword(SwiftParsingKeyword.STRUCT.value)) + \
-                (~pp.Keyword(SwiftParsingKeyword.VAR.value) & ~pp.Keyword(SwiftParsingKeyword.FUNC.value)) + \
+            match_expression = (pp.Keyword(SwiftParsingKeyword.CLASS.value) | pp.Keyword(SwiftParsingKeyword.STRUCT.value) | pp.Keyword(SwiftParsingKeyword.ENUM.value) | pp.Keyword(SwiftParsingKeyword.PROTOCOL.value)) + \
+                (~pp.Keyword(SwiftParsingKeyword.LET.value) & ~pp.Keyword(SwiftParsingKeyword.VAR.value) & ~pp.Keyword(SwiftParsingKeyword.FUNC.value)) + \
                 entity_name.setResultsName(CoreParsingKeyword.ENTITY_NAME.value) + \
                 pp.Optional(pp.Keyword(CoreParsingKeyword.COLON.value)) + pp.SkipTo(pp.FollowedBy(SwiftParsingKeyword.OPEN_SCOPE.value))
 


### PR DESCRIPTION
### Improve Swift language support
- Add support for the following keywords `protocol`, `enum`, `let` as described in #12 point 1.

### Test Source code:
```
import Foundation

protocol Naming {
    var name: String { get set }
}

protocol Describing {
    var describing: String { get }
}

class ClassA: Naming & Describing {
    
    static let shared = ClassA()
    
    var name: String = "A"
    let id: UUID = UUID()
    var describing: String = "Class A"
}

class ClassB: ClassA {
    func show() {
        print(name)
    }
}

enum EnumA {
    case one
    case two(EnumB)
}

enum EnumB: String, Describing {
    case one
    case two
    
    var describing: String {
        self.rawValue
    }
}

struct StructC<T: Naming>: Describing {
    var name: String = "C"
    let state: EnumA = .one
    var generic: T
    
    var describing: String = "Class C"
    
    init(generic: T) {
        self.generic = generic
    }
}

public struct EmergeSwiftTest {
    public private(set) var text = "Hello, World!"

    var b = ClassB()
    let eB: EnumB = .one
    let eA = EnumA.two(.one)
    
    func show() {
        b.show()
        print(ClassA.shared.name)
    }
}
```

### Output:
<img width="545" alt="Screenshot 2022-01-16 at 13 42 39" src="https://user-images.githubusercontent.com/8319309/149662728-9b818012-55b4-4991-9458-6c1472aaa922.png">

## Desired output:

- [x] `Naming` doesn't depend from other entities
- [x] `Describing` doesn't depend from other entities
- [x] `ClassA` depends on `Naming`, `Describing`
- [x] `ClassB` depends on `ClassA`
- [x] `EnumA` depends on `EnumB`
- [x] `EnumB` depends on `Describing`
- [x] `StructC` depends on `Naming`, `Describing`, `EnumA`
- [ ] `EmergeSwiftTest` depends on `ClassB`, `EnumB` (** Not supported by this change `EnumA`, `ClassA`)

Note:
** Static entities are not evaluated
