### PR TITLE
A comment for only_permit_files_matching_absolute_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ The yaml configuration is basically defined at the following levels:
 | `ignore_directories_containing`  | exclude directory names from the scan that contain the given substrings |
 | `only_permit_languages`          | possible values include: java, kotlin, objc, swift, ruby, groovy, javascript, c - explicitly prevents any other language from scanning besides the one you set here |
 | `only_permit_file_extensions`    | explicitly permit the following file extensions you set here, e.g. `.java` |
-| `only_permit_files_matching_absolute_path`    | only the following list of absolute file paths is permitted for the file scan, e.g. `/Users/user1/source/file1.java` |
+| `only_permit_files_matching_absolute_path`    | only the following list of absolute file paths is permitted for the file scan, e.g. `[/Users/user1/source/file1.java]`. The files should follow `source_directory`|
 | `ignore_dependencies_containing` | ignore every dependency included in this list of substrings, e.g. `java.util` |
 | `import_aliases`  | define a list of import aliases, i.e. replace substrings within a full dependency path, e.g. `"@foo": src/foo` will replace any `@foo` alias by `src/foo` |
 | `file_scan`                      | perform a file scan, contains the metrics that should be applied on every source file |


### PR DESCRIPTION
I was trying to test `only_permit_files_matching_absolute_path`, but when I put:
```
only_permit_files_matching_absolute_path: /Users/israteneda/Code/springfield/cases/taxes.py
```
I got an error:
```
File "/Users/israteneda/.pyenv/versions/3.10.0/envs/venv-3.10.0/lib/python3.10/site-packages/sklearn/feature_extraction/text.py", line 1220, in _count_vocab
    raise ValueError(
ValueError: empty vocabulary; perhaps the documents only contain stop words
```
So, I was thinking to add some comments about this flag.