### PR TITLE
Possibly fixes #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,8 @@ The yaml configuration is basically defined at the following levels:
 | `ignore_entities_containing` | ignore every entity included in this list of substrings, e.g. `NotRelevantClass` |
 | `ignore_entities_matching` | ignore every entity matching any of the regular expressions in this list of substrings, e.g. `^Test` |
 | `import_aliases`  | define a list of import aliases, i.e. replace substrings within a full dependency path, e.g. `"@foo": src/foo` will replace any `@foo` alias by `src/foo` |
+| `override_resolve_dependencies` | if supported by the language parser, force every dependency in this list to be resolved |
+| `override_do_not_resolve_dependencies` | if supported by the language parser, force every dependency in this list NOT to be resolved (i.e. treated as a global dependency) |
 | `file_scan`                      | perform a file scan, contains the metrics that should be applied on every source file |
 | `entity_scan`                    | perform an entity scan, contains the metrics that should be applied on every entity (e.g. on every class) |
 | `export`                         | contains any export formats that should be created as output |

--- a/emerge/analysis.py
+++ b/emerge/analysis.py
@@ -83,6 +83,9 @@ class Analysis:
         self.import_aliases_available: bool = False
         self.import_aliases: Dict[str, str] = {}
 
+        self.override_resolve_dependencies: List[str] = []
+        self.override_do_not_resolve_dependencies: List[str] = []
+
         self.results: Dict[str, AbstractResult] = {}
 
         self.absolute_scanned_file_names: Set[str] = set()

--- a/emerge/config.py
+++ b/emerge/config.py
@@ -72,6 +72,8 @@ class ConfigKeyAnalysis(EnumKeyValid, Enum):
     IGNORE_FILES_CONTAINING = auto()
     IGNORE_DEPENDENCIES_CONTAINING = auto()
     IGNORE_ENTITIES_CONTAINING = auto()
+    OVERRIDE_RESOLVE_DEPENDENCIES = auto()
+    OVERRIDE_DO_NOT_RESOLVE_DEPENDENCIES = auto()
     IMPORT_ALIASES = auto()
     FILE_SCAN = auto()
     ENTITY_SCAN = auto()
@@ -511,6 +513,16 @@ class Configuration:
                 else:
                     raise Exception(f'❗️{ConfigKeyAnalysis.ONLY_PERMIT_FILES_MATCHING_ABSOLUTE_PATH.name.lower()} '
                                       f'must be a list of strings.')
+
+            # check if our config forces us to resolve a given subset of dependencies
+            if ConfigKeyAnalysis.OVERRIDE_RESOLVE_DEPENDENCIES.name.lower() in analysis_dict:
+                for overridden_resolve_dependency in analysis_dict[ConfigKeyAnalysis.OVERRIDE_RESOLVE_DEPENDENCIES.name.lower()]:
+                    analysis.override_resolve_dependencies.append(overridden_resolve_dependency)
+
+            # check if our config forces us to NOT resolve a given subset of dependencies
+            if ConfigKeyAnalysis.OVERRIDE_DO_NOT_RESOLVE_DEPENDENCIES.name.lower() in analysis_dict:
+                for overridden_dont_resolve_dependency in analysis_dict[ConfigKeyAnalysis.OVERRIDE_DO_NOT_RESOLVE_DEPENDENCIES.name.lower()]:
+                    analysis.override_do_not_resolve_dependencies.append(overridden_dont_resolve_dependency)
 
             # load metrics from analysis
             if ConfigKeyAnalysis.FILE_SCAN.name.lower() in analysis_dict:

--- a/emerge/languages/pyparser.py
+++ b/emerge/languages/pyparser.py
@@ -66,7 +66,7 @@ class PythonParser(AbstractParser, ParsingMixin):
             '>': ' > ',
             '"': ' " '
         }
-        self.global_depenency_autodetect_set: Set[str] = self.create_autotetect_set()
+        self.global_depenency_autodetect_set: Set[str] = self.create_autodetect_set()
 
     @classmethod
     def parser_name(cls) -> str:
@@ -306,7 +306,7 @@ class PythonParser(AbstractParser, ParsingMixin):
     def _add_package_name_to_result(self, result: FileResult):
         result.module_name = ""
 
-    def create_autotetect_set(self) -> Set[str]:
+    def create_autodetect_set(self) -> Set[str]:
         global_depenency_autodetect_set: Set[str] = set()
    
         # first global dependency detection attempt

--- a/emerge/languages/pyparser.py
+++ b/emerge/languages/pyparser.py
@@ -66,7 +66,7 @@ class PythonParser(AbstractParser, ParsingMixin):
             '>': ' > ',
             '"': ' " '
         }
-        self.global_depenency_autodetect_set: Set[str] = self.create_autodetect_set()
+        self.global_dependency_autodetect_set: Set[str] = self.create_autodetect_set()
 
     @classmethod
     def parser_name(cls) -> str:
@@ -307,7 +307,7 @@ class PythonParser(AbstractParser, ParsingMixin):
         result.module_name = ""
 
     def create_autodetect_set(self) -> Set[str]:
-        global_depenency_autodetect_set: Set[str] = set()
+        global_dependency_autodetect_set: Set[str] = set()
    
         # first global dependency detection attempt
         for module in pkg_resources.working_set:
@@ -321,26 +321,26 @@ class PythonParser(AbstractParser, ParsingMixin):
             
             if module_name_from_metadata:
                 if '-' not in module_name_from_metadata and '__' not in module_name_from_metadata and not module_name_from_metadata.startswith('_'):
-                    global_depenency_autodetect_set.add(module_name_from_metadata)
+                    global_dependency_autodetect_set.add(module_name_from_metadata)
 
         # second global dependency detection attempt
         second_global_module_detection_appempt = list(freeze())
         processed_result_second_detection = [x.split('==', 1)[0].replace('-','_').lower() for x in second_global_module_detection_appempt]
         for element in processed_result_second_detection:
-            global_depenency_autodetect_set.add(element)
+            global_dependency_autodetect_set.add(element)
 
         # third global dependency (built-in module) detection attempt
         for builtin_module in sys.modules:
             if not builtin_module.startswith('_') and not '.' in builtin_module:
-                global_depenency_autodetect_set.add(builtin_module)
+                global_dependency_autodetect_set.add(builtin_module)
 
-        return global_depenency_autodetect_set
+        return global_dependency_autodetect_set
 
 
     def dependency_is_global(self, dependency: str, analysis) -> bool:
         assumption = False # assume the dependency is global or not
 
-        if dependency in self.global_depenency_autodetect_set:
+        if dependency in self.global_dependency_autodetect_set:
             assumption = True
 
         # now check if our configuration forces us to treat the dependency as global or not

--- a/emerge/languages/pyparser.py
+++ b/emerge/languages/pyparser.py
@@ -5,13 +5,16 @@ Contains the implementation of the Python language parser and a relevant keyword
 # Authors: Grzegorz Lato <grzegorz.lato@gmail.com>
 # License: MIT
 
-from typing import Dict
+from typing import Dict, Set
 from enum import Enum, unique
 
 import logging
 from pathlib import Path
 import os
 import sys
+
+import pkg_resources
+from pip._internal.operations.freeze import freeze
 
 import coloredlogs
 import pyparsing as pp
@@ -63,6 +66,7 @@ class PythonParser(AbstractParser, ParsingMixin):
             '>': ' > ',
             '"': ' " '
         }
+        self.global_depenency_autodetect_set: Set[str] = self.create_autotetect_set()
 
     @classmethod
     def parser_name(cls) -> str:
@@ -248,9 +252,9 @@ class PythonParser(AbstractParser, ParsingMixin):
 
             # all other cases
             elif not multiple_imports_from_relative_current_dir and not multiple_imports_from_relative_parent_dir:
-
-                # assumption: if a dependency is in sys.modules, assume its global and do not try to resolve/add any paths
-                if dependency in sys.modules:
+                
+                # try to autodetect | override if a dependency should be resolved or kept as global_import
+                if self.dependency_is_global(dependency, analysis):
                     global_import = True
 
                 if PythonParsingKeyword.PYTHON_IMPORT_PARENT_DIR.value in dependency:
@@ -301,6 +305,51 @@ class PythonParser(AbstractParser, ParsingMixin):
 
     def _add_package_name_to_result(self, result: FileResult):
         result.module_name = ""
+
+    def create_autotetect_set(self) -> Set[str]:
+        global_depenency_autodetect_set: Set[str] = set()
+   
+        # first global dependency detection attempt
+        for module in pkg_resources.working_set:
+            
+            try:
+                # pylint: disable=protected-access
+                module_name_from_metadata = next(pkg_resources.get_distribution(module.key)._get_metadata('top_level.txt')) # type: ignore
+
+            except: # pylint: disable=bare-except
+                module_name_from_metadata = None
+            
+            if module_name_from_metadata:
+                if '-' not in module_name_from_metadata and '__' not in module_name_from_metadata and not module_name_from_metadata.startswith('_'):
+                    global_depenency_autodetect_set.add(module_name_from_metadata)
+
+        # second global dependency detection attempt
+        second_global_module_detection_appempt = list(freeze())
+        processed_result_second_detection = [x.split('==', 1)[0].replace('-','_').lower() for x in second_global_module_detection_appempt]
+        for element in processed_result_second_detection:
+            global_depenency_autodetect_set.add(element)
+
+        # third global dependency (built-in module) detection attempt
+        for builtin_module in sys.modules:
+            if not builtin_module.startswith('_') and not '.' in builtin_module:
+                global_depenency_autodetect_set.add(builtin_module)
+
+        return global_depenency_autodetect_set
+
+
+    def dependency_is_global(self, dependency: str, analysis) -> bool:
+        assumption = False # assume the dependency is global or not
+
+        if dependency in self.global_depenency_autodetect_set:
+            assumption = True
+
+        # now check if our configuration forces us to treat the dependency as global or not
+        if dependency in analysis.override_resolve_dependencies and not dependency in analysis.override_do_not_resolve_dependencies:
+            assumption = False
+        elif dependency in analysis.override_do_not_resolve_dependencies and not dependency in analysis.override_resolve_dependencies:
+            assumption = True
+        
+        return assumption
 
 
 if __name__ == "__main__":

--- a/emerge/languages/pyparser.py
+++ b/emerge/languages/pyparser.py
@@ -11,6 +11,7 @@ from enum import Enum, unique
 import logging
 from pathlib import Path
 import os
+import sys
 
 import coloredlogs
 import pyparsing as pp
@@ -247,6 +248,11 @@ class PythonParser(AbstractParser, ParsingMixin):
 
             # all other cases
             elif not multiple_imports_from_relative_current_dir and not multiple_imports_from_relative_parent_dir:
+
+                # assumption: if a dependency is in sys.modules, assume its global and do not try to resolve/add any paths
+                if dependency in sys.modules:
+                    global_import = True
+
                 if PythonParsingKeyword.PYTHON_IMPORT_PARENT_DIR.value in dependency:
                     relative_import = True
                     dependency = dependency.replace(PythonParsingKeyword.PYTHON_IMPORT_PARENT_DIR.value, CoreParsingKeyword.POSIX_PARENT_DIRECTORY.value)


### PR DESCRIPTION
@and3rson This possibly fixes #29 in checking if the dependency can be found in `sys.modules` and if so - setting `global_import` to `True`. This seems to solve the reproducible example you've described above (see my screenshot). Also tried it on a bigger codebase (Django), as one would assume it reduces nodes and edges.

<img width="712" alt="CleanShot 2022-10-19 at 20 23 29@2x" src="https://user-images.githubusercontent.com/9966438/196775385-580a7c30-68e5-4d4f-834d-74921ac68a62.png">