### PR TITLE
Change sklearn requirement to scikit-learn.

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -40,7 +40,7 @@ autopep8
 coloredlogs
 interrogate
 networkx
-sklearn
+scikit-learn
 numpy
 prettytable
 py

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ autopep8
 coloredlogs
 interrogate
 networkx
-sklearn
+scikit-learn
 numpy
 prettytable
 py

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "coloredlogs",
         "interrogate",
         "networkx",
-        "sklearn",
+        "scikit-learn",
         "numpy",
         "prettytable",
         "py",


### PR DESCRIPTION
The `sklearn` package is deprecated in favor of `scikit-learn`. A brownout began Dec 1, 2022 and the package will be unavailable after December 1st, 2023. See: https://pypi.org/project/sklearn/

This PR updates references to the `sklearn` dependency to `scikit-learn`. Note that the correct import name is still `sklearn`, though.