### PR TITLE
Add additional install step on Apple Silicon Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,23 @@ git clone https://github.com/glato/emerge.git
 brew install graphviz
 ```
 
+If you encounter the following error on an Apple silicon Mac
+
+```sh
+pygraphviz/graphviz_wrap.c:2711:10: fatal error: 'graphviz/cgraph.h' file not found
+      #include "graphviz/cgraph.h"
+               ^~~~~~~~~~~~~~~~~~~
+      1 error generated.
+```
+
+you need to run the following command once to update the pygraphviz include directories for the new homebrew environment
+
+```sh
+pip install --global-option=build_ext --global-option="-I$(brew --prefix graphviz)/include/" --global-option="-L$(brew --prefix graphviz)/lib/" pygraphviz
+```
+
+See the issue in context [here](https://github.com/pygraphviz/pygraphviz/issues/11).
+
 ### 2️⃣.2️⃣ ~ (*macOS*) Create a virtual environment
 
 Check of you have the latest Python 3 installed on your macOS. I recommend installing/using Python 3 from [Homebrew](https://brew.sh). Create a Python 3 virtual environment (optionally within the project structure)


### PR DESCRIPTION
Hi @glato ,

while setting up emerge on an Apple Silicon Mac I've encountered the following issue with the graphviz dependency:

```sh
  × Running setup.py install for pygraphviz did not run successfully.
  │ exit code: 1
  ╰─> [57 lines of output]
      running install
      /Users/ctreffs/Developer/personal/emerge/venv/lib/python3.10/site-packages/setuptools/command/install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
        warnings.warn(
      running build
      running build_py
      creating build
      creating build/lib.macosx-13.1-arm64-cpython-310
      creating build/lib.macosx-13.1-arm64-cpython-310/pygraphviz
      copying pygraphviz/scraper.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz
      copying pygraphviz/graphviz.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz
      copying pygraphviz/__init__.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz
      copying pygraphviz/agraph.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz
      copying pygraphviz/testing.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz
      creating build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_unicode.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_scraper.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_readwrite.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_string.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/__init__.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_html.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_node_attributes.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_drawing.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_repr_mimebundle.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_subgraph.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_close.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_edge_attributes.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_clear.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_layout.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_attribute_defaults.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      copying pygraphviz/tests/test_graph.py -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz/tests
      running egg_info
      writing pygraphviz.egg-info/PKG-INFO
      writing dependency_links to pygraphviz.egg-info/dependency_links.txt
      writing top-level names to pygraphviz.egg-info/top_level.txt
      reading manifest file 'pygraphviz.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      warning: no files found matching '*.png' under directory 'doc'
      warning: no files found matching '*.txt' under directory 'doc'
      warning: no files found matching '*.css' under directory 'doc'
      warning: no previously-included files matching '*~' found anywhere in distribution
      warning: no previously-included files matching '*.pyc' found anywhere in distribution
      warning: no previously-included files matching '.svn' found anywhere in distribution
      no previously-included directories found matching 'doc/build'
      adding license file 'LICENSE'
      writing manifest file 'pygraphviz.egg-info/SOURCES.txt'
      copying pygraphviz/graphviz.i -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz
      copying pygraphviz/graphviz_wrap.c -> build/lib.macosx-13.1-arm64-cpython-310/pygraphviz
      running build_ext
      building 'pygraphviz._graphviz' extension
      creating build/temp.macosx-13.1-arm64-cpython-310
      creating build/temp.macosx-13.1-arm64-cpython-310/pygraphviz
      clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -g -fwrapv -O3 -Wall -DSWIG_PYTHON_STRICT_BYTE_CHAR -I/Users/ctreffs/Developer/personal/emerge/venv/include -I/Users/ctreffs/.pyenv/versions/3.10.0/include/python3.10 -c pygraphviz/graphviz_wrap.c -o build/temp.macosx-13.1-arm64-cpython-310/pygraphviz/graphviz_wrap.o
      pygraphviz/graphviz_wrap.c:2711:10: fatal error: 'graphviz/cgraph.h' file not found
      #include "graphviz/cgraph.h"
               ^~~~~~~~~~~~~~~~~~~
      1 error generated.
      error: command '/opt/homebrew/opt/llvm/bin/clang' failed with exit code 1
      [end of output]
```

After some searching I found a solution to a known issue for pygraphviz: https://github.com/pygraphviz/pygraphviz/issues/11

I've extended the README.md to include this and hope this helps others in the future.

