### PR TITLE
Fix git metrics for languages that don't support entity parsing

### DIFF
--- a/emerge/output/html/resources/js/emerge_git.js
+++ b/emerge/output/html/resources/js/emerge_git.js
@@ -110,7 +110,7 @@ function calculateAuthorsForDateRange() {
 }
 
 function addGitMetricToFileNodes() {
-    if (currentGraphType.includes('file_result_dependency_graph')) {
+    if (currentGraph && currentGraphType.includes('file_result_dependency_graph')) {
         let fileChurnMap = calculateFileChurnForDateRange()
         let whiteSpaceComplexityMap = calculateWhiteSpaceComplexityForDateRange()
         let slocMap = calculateSlocForDateRange()

--- a/emerge/tests/parsers/test_parsing_mixin.py
+++ b/emerge/tests/parsers/test_parsing_mixin.py
@@ -63,7 +63,8 @@ class ParsingMixinTestCase(unittest.TestCase):
             scanned_by="parser_name",
             scanned_language=LanguageType.JAVASCRIPT,
             scanned_tokens="token1 token2",
-            preprocessed_source=""
+            source="",
+            preprocessed_source="",
         )
 
         resolved_dependency1 = ParsingMixin.resolve_relative_dependency_path(


### PR DESCRIPTION
# Summary

Check that `currentGraph` is defined `addGitMetricToFileNodes` before attempting to update git metrics.

Languages that don't support entity parsing attempted to update the graph with git metrics before `currentGraph` was defined on initial rendering.

# Issue

To reproduce the issue (before this change), you can run the following in this repo:
```sh
python3 emerge.py -c py-template.yaml
```
using the following `py-template.yaml` (default python config with `git_directory` and `git-metrics` added):
```yaml
---
project_name: py-example-project
loglevel: info
analyses:
- analysis_name: py check
  source_directory: emerge
  git_directory: ./.git
  only_permit_languages:
  - py
  only_permit_file_extensions:
  - .py
  file_scan:
  - git_metrics
  - number_of_methods
  - source_lines_of_code
  - dependency_graph
  - louvain_modularity
  - fan_in_out
  - tfidf
  export:
  - directory: emerge-output
  - graphml
  - json
  - tabular_file
  - tabular_console_overall
  - d3
```

Opening the output html (i.e. `emerge-output/html/emerge.html`) won't display a graph due to the error described above.