### PR TITLE
Use fixed size node tooltip

### DIFF
--- a/emerge/output/html/resources/js/emerge_graph.js
+++ b/emerge/output/html/resources/js/emerge_graph.js
@@ -271,7 +271,7 @@ function drawNodes(context) {
                 context.lineWidth = 1.0;
                 context.stroke();
                 
-                drawNodeToolTip(closeNode.id, closeNode.x + 14, closeNode.y - 7, closeNode.metrics)
+                drawNodeToolTip(closeNode.id, closeNode.x + 8, closeNode.y - 7, closeNode.metrics)
             }
         }
     });
@@ -357,115 +357,123 @@ function stringIncludedInNodeContributors(string, node) {
 function drawNodeToolTip(text, xPos, yPos, nodeMetrics) {
     
     // $('#overallStatisticsModal').modal('show');
-    
-    const fontSize = 14
-    context.font = fontSize + 'px Helvetica';
-    
-    // determine the maximum label width
-    let maxLineWidth = 0
+
+    // Calculate scale factor to maintain fixed size when d3 canvas zoom changes.
+    const zoomTransform = d3.zoomTransform(context.canvas);
+    const scaleFactor = 1 / zoomTransform.k;
+
+    // Scale linewidth and font so they're unchanged when zooming:
+    context.lineWidth = scaleFactor;
+    const scaledFontSize = 14 * scaleFactor;
+    context.font = scaledFontSize + 'px Helvetica';
+
+    // Set the text box width based on the maximum label width
+    let textBoxWidth = 0;
     for (metricKey in nodeMetrics) {
-        const val = nodeMetrics[metricKey]
+        const val = nodeMetrics[metricKey];
         let human_readable_metric_name = metricKey.replace('metric_', '').replace(/_/gi, " ")
         const w = context.measureText(human_readable_metric_name + ": " + val).width;
-        if (maxLineWidth < w) {
-            maxLineWidth = w
+        if (textBoxWidth < w) {
+            textBoxWidth = w;
         }
     }
     
     // check if actually the title line width if bigger than any metric label line width?
     const nodeTitleLineWidth = context.measureText(text).width
-    if (nodeTitleLineWidth > maxLineWidth)
-    maxLineWidth = nodeTitleLineWidth
+    if (nodeTitleLineWidth > textBoxWidth) {
+        textBoxWidth = nodeTitleLineWidth;
+    }
     
-    // draw the header/title of the toolip    
-    let lineHeight = fontSize * 1.286;
-    context.fillStyle = hexToRGB("#0069d9", 1.0);
-    context.fillRect(xPos - 6, (yPos - lineHeight) + 2, maxLineWidth + 10, lineHeight + 4);
-    context.strokeStyle = hexToRGB("#333333", 1.0);
-    context.strokeRect(xPos - 6, (yPos - lineHeight) + 2, maxLineWidth + 10, lineHeight + 4)
-    
+    // Offset text from left edge of box:
+    const xTextOffset = 5 * scaleFactor;
+    const xText = xPos + xTextOffset;
+    // Offset text from bottom edge of box:
+    const yTextOffset = 5 * scaleFactor;
+    // yCurrent represents the bottom edge of the box, which changes for each box:
+    let yCurrent = yPos;
+
+    // Define dimensions of each box/row containing metrics/labels/tags:
+    const boxWidth = textBoxWidth + 2 * xTextOffset;
+    const boxHeight = scaledFontSize * 1.286;
+    const boxDefaults = { x: xPos, width: boxWidth, height: boxHeight };
+
+    // Draw the header/title with node label:
+    drawBox(context,
+        { y: yCurrent - boxHeight, ...boxDefaults },
+        { strokeColor: hexToRGB("#333333", 1.0), fillColor: hexToRGB("#0069d9", 1.0) },
+    );
     context.fillStyle = hexToRGB("#FFFFFF", 0.8);
-    context.fillText(text, xPos, yPos);
+    context.fillText(text, xText, yCurrent - yTextOffset);
     
-    // now draw the second tooltip box with all metric labels
-    let metricItem = 1
-    const metricFontSize = 14
-    const metricLineHeight = (metricFontSize * 1.286);
-    let yPosOffset = yPos + 10
-    let newYPos = 0
-    let renderWithTags = false
-    
-    context.font = metricFontSize + 'px Helvetica';
-    
+    // Draw boxes/rows for all metric labels
+    let renderWithTags = false;
     for (metricKey in nodeMetrics) {
-        
-        // do not include any tag/tfidf metric in the primary metric section
+        // Do not include any tag/tfidf metrics in the primary metric section:
         if (metricKey.includes('metric_tag')) {
-            renderWithTags = true
+            renderWithTags = true;
             continue
         }
         
-        let val = nodeMetrics[metricKey]
-        let human_readable_metric_name = metricKey.replace('metric_', '').replace(/_/gi, " ")
-        let metricItemText = human_readable_metric_name + ": " + val
+        // Shift `yCurrent` (bottom edge of the box) by the boxHeight:
+        yCurrent += boxHeight;
         
-        newYPos = yPosOffset + (metricLineHeight * metricItem)
+        let human_readable_metric_name = metricKey.replace('metric_', '').replace(/_/gi, " ");
+        let metricItemText = human_readable_metric_name + ": " + nodeMetrics[metricKey];
         
-        // Interesting bug: on Safari it seems to cause random lags if you do fillStyle/fillRect BEFORE strokeStyle/strokeRect
-        context.strokeStyle = toolTipMetricItemBoxColor
-        context.strokeRect(xPos - 6, (newYPos - metricLineHeight), maxLineWidth + 10, metricLineHeight)
-        
-        context.fillStyle = toolTipMetricItemBoxFillColor
-        context.fillRect(xPos - 6, (newYPos - metricLineHeight), maxLineWidth + 10, metricLineHeight);
-        
+        // Draw box with current metric label:
+        drawBox(context,
+            { y: yCurrent - boxHeight, ...boxDefaults },
+            { strokeColor: toolTipMetricItemBoxColor, fillColor: toolTipMetricItemBoxFillColor },
+        );
         context.fillStyle = toolTipMetricItemTextColor;
-        context.fillText(metricItemText, xPos, newYPos - 4);
-        
-        metricItem = metricItem + 1
+        context.fillText(metricItemText, xText, yCurrent - yTextOffset);
     }
     
-    // render tag/tfidf metric section
+    // Draw boxes/rows for tag/tfidf metric section:
     if (renderWithTags) {
-        let metricItem = 1
-        newYPos += 20
+        // Shift `yCurrent` (bottom edge of the box) by the boxHeight:
+        yCurrent += boxHeight;
         
-        // draw the header/title of the toolip    
-        context.fillStyle = hexToRGB("#f5bc42", 1.0);
-        context.fillRect(xPos - 6, (newYPos - lineHeight) + 2, maxLineWidth + 10, lineHeight + 4);
-        context.strokeStyle = hexToRGB("#333333", 1.0);
-        context.strokeRect(xPos - 6, (newYPos - lineHeight) + 2, maxLineWidth + 10, lineHeight + 4)
+        // Draw the header/title for the tag/tfidf section:
+        drawBox(context,
+            { y: yCurrent - boxHeight, ...boxDefaults },
+            { strokeColor: hexToRGB("#333333", 1.0), fillColor: hexToRGB("#f5bc42", 1.0) },
+        );
         context.fillStyle = hexToRGB("#333333", 0.8);
-        context.fillText('Semantic keywords', xPos, newYPos);
+        context.fillText('Semantic keywords', xText, yCurrent - yTextOffset);
         
-        let yTagPosOffset = newYPos + 10
-        
-        // render tag/tfidf metrics
+        // Draw boxes/rows for all tag/tfidf metrics:
         for (metricKey in nodeMetrics) {
             
-            // do not include any tag/tfidf metric in the primary metric section
+            // Skip metrics that aren't tag/tfidf metrics:
             if (!metricKey.includes('metric_tag')) {
                 continue
             }
             
-            let val = nodeMetrics[metricKey]
-            let human_readable_metric_name = metricKey.replace('metric_tag', '').replace(/_/gi, "")
-            let metricItemText = human_readable_metric_name // + ": " + val
+            // Shift `yCurrent` (bottom edge of the box) by the boxHeight:
+            yCurrent += boxHeight;
             
-            newYPos = yTagPosOffset + (metricLineHeight * metricItem)
+            let metricItemText = metricKey.replace('metric_tag', '').replace(/_/gi, "");
             
-            // Interesting bug: on Safari it seems to cause random lags if you do fillStyle/fillRect BEFORE strokeStyle/strokeRect
-            context.strokeStyle = toolTipMetricItemBoxColor
-            context.strokeRect(xPos - 6, (newYPos - metricLineHeight), maxLineWidth + 10, metricLineHeight)
-            
-            context.fillStyle = toolTipMetricItemBoxFillColor
-            context.fillRect(xPos - 6, (newYPos - metricLineHeight), maxLineWidth + 10, metricLineHeight);
-            
+            // Draw box with current tag/tfidf:
+            drawBox(context,
+                { y: yCurrent - boxHeight, ...boxDefaults },
+                { strokeColor: toolTipMetricItemBoxColor, fillColor: toolTipMetricItemBoxFillColor },
+            );
             context.fillStyle = toolTipMetricItemTextColor;
-            context.fillText(metricItemText, xPos, newYPos - 4);
-            
-            metricItem = metricItem + 1
+            context.fillText(metricItemText, xText, yCurrent - yTextOffset);
         }
     }
+}
+
+
+function drawBox(context, {x, y, width, height}, {strokeColor, fillColor}) {
+    // Interesting bug: on Safari it seems to cause random lags if you do fillStyle/fillRect BEFORE strokeStyle/strokeRect
+    context.strokeStyle = strokeColor;
+    context.strokeRect(x, y, width, height);
+    
+    context.fillStyle = fillColor
+    context.fillRect(x, y, width, height);
 }
 
 // borrowed from Scott Johnson / https://gist.github.com/jwir3/d797037d2e1bf78a9b04838d73436197 with minor adjustments


### PR DESCRIPTION
# Overview

Currently, the tooltip overlay displayed when hovering over a node is scaled with the canvas---if the you zoom out, the overlay shrinks with the nodes; if you zoom in, it grows. 

This zooming behavior is not desirable in many cases since the tooltips are meant to be read. If it's too small to read, it's not very useful; if it's larger than the desired font size, then it's taking up unnecessary real estate on the screen. The tooltip should be treated the same way as the menu pane, which remains fixed size.

# Current Behavior

For example, here's the current behavior at 0.5x zoom, where the text is barely legible:

<img width="1130" alt="current-zoom-factor-0 5" src="https://github.com/glato/emerge/assets/133031/464a6ff0-2122-4841-8e4d-db10922b98f9">

And at 2x zoom, it much more screen space than needed:

<img width="1150" alt="current-zoom-factor-2 0" src="https://github.com/glato/emerge/assets/133031/6323e4d4-2c9a-41d1-85f0-c4aad1ba7de4">

# New Behavior

After the changes in this pull request, the tooltip is a fixed size regardless of the zoom level. The same examples of 0.5x and 2x zoom look like the following on this branch:

<img width="1124" alt="fixed-scale-zoom-factor-0 5" src="https://github.com/glato/emerge/assets/133031/e2014bf9-a0d8-4375-9986-e813717d7d1d">

<img width="1127" alt="fixed-scale-zoom-factor-2 0" src="https://github.com/glato/emerge/assets/133031/8020f926-537b-4043-8bfe-3ba9c2e727b0">



