### PR TITLE
Add ignore rule for __pycache__ directories in default python template

### DIFF
--- a/emerge/configs/py-template.yaml
+++ b/emerge/configs/py-template.yaml
@@ -8,6 +8,8 @@ analyses:
   - py
   only_permit_file_extensions:
   - .py
+  ignore_directories_containing:
+  - __pycache__
   file_scan:
   - number_of_methods
   - source_lines_of_code


### PR DESCRIPTION
This is a very simple change, but basically the `__pycache__` directory should be ignored by default for python projects. This is most noticeable looking at the filesystem graph for a python project, which will contain directories as leaf-nodes (since none of the files in that directory have a `.py` extension). Here's an example running emerge on the emerge repo without this ignore rule:

<img width="694" alt="image" src="https://github.com/glato/emerge/assets/133031/9bb6a571-7b11-49a2-8e58-5a9d5d0e2457">

Note that all the blue leaf nodes in this image are from `__pycache__` directories.