### PR TITLE
Fix-config-file-logging-message

### DIFF
--- a/emerge/config.py
+++ b/emerge/config.py
@@ -732,7 +732,7 @@ class YamlLoader:
             with open(yaml_file_name, encoding="utf-8") as yaml_file:
                 self._config_file_content = yaml_file.read()
         except OSError:
-            LOGGER.error(f'coould not open file: {yaml_file_name}')
+            LOGGER.error(f'could not open file: {yaml_file_name}')
 
     def _load_yaml_from_config_file_content(self):
         try:


### PR DESCRIPTION
Previously: the logging message was "coould not open file" in config.py file
Now: the logging message is "could not open file".