### PR TITLE
fix: Issue 49 | Filter ignore_files_containing by substring instead of the whole file name

### DIFF
--- a/emerge/analysis.py
+++ b/emerge/analysis.py
@@ -479,7 +479,7 @@ class Analysis:
                 filesystem_graph.digraph.add_edge(relative_path_parent, relative_path_directoy_node)
 
             if self.ignore_files_containing:
-                files[:] = [f for f in files if f not in self.ignore_files_containing]
+                files[:] = [f for f in files if not any(substring in f for substring in self.ignore_files_containing)]
 
             for file_name in files:
                 absolute_path_to_file = os.path.join(root, file_name)

--- a/emerge/export.py
+++ b/emerge/export.py
@@ -262,6 +262,13 @@ class D3Exporter:
             graph = graph_representation.digraph
             data = json_graph.node_link_data(graph)
 
+            # write data into a json file
+            target_export_file_path = export_dir + \
+                '/' + 'emerge-' + graph_representation.graph_type.name.lower() + '-data.json'
+            
+            with open(target_export_file_path, 'w', encoding="utf-8") as file:
+                json.dump(data, file)
+
             d3_js_string += 'const ' + graph_representation.graph_type.name.lower() + ' = ' + json.dumps(data)
             json_statistics = {}
             json_metrics = {}


### PR DESCRIPTION
Addressing the [Issue 49](https://github.com/glato/emerge/issues/49)