### PR TITLE
add .hpp extension support for C and CPP parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ You can simply install emerge by using `pip`.
 On Ubuntu 20.04+ pleaase make sure that the packages `graphviz` and `graphviz-dev` are installed, i.e.
 
 ```text
-apt-get install graphviz graphviz-dev 
+apt-get install graphviz graphviz-dev
 ```
 
 ### 1️⃣.2️⃣ ~ Install with pip
@@ -195,7 +195,7 @@ You can create a simple project config adhoc from the command line and then simp
 and then simply adjust the necessary paths (`analyses/source_directory` and `export/directory`):
 
 ```text
-(emerge) user@host tmp % cat java-template.yaml 
+(emerge) user@host tmp % cat java-template.yaml
 ---
 project_name: java_project_example
 loglevel: info
@@ -349,7 +349,7 @@ If you got in any trouble executing the tests, check [this woraround](https://gi
 ### 6️⃣ ~ Running `emerge` as a standalone tool
 
 ```text
-(emerge) user@host emerge % python emerge.py 
+(emerge) user@host emerge % python emerge.py
 usage: emerge.py [-h] [-c YAMLCONFIG] [-v] [-d] [-e] [-a LANGUAGE]
 
 🔎 Welcome to emerge x.y.z (yyyy-mm-dd hh:mm:ss)
@@ -643,8 +643,8 @@ Emerge supports the following file extensions and scan types per language, where
 |---------------------------|-----------------|-------|---------
 | `.java`                   | Java            | ✅ | ✅
 | `.swift`                  | Swift           | ✅ | ✅
-| `.c` / `.h`               | C               | ✅ | ❌
-| `.cpp` / `.h`             | C++             | ✅ | ❌
+| `.c` / `.h` / `.hpp`      | C               | ✅ | ❌
+| `.cpp` / `.h` / `.hpp`    | C++             | ✅ | ❌
 | `.groovy`                 | Groovy          | ✅ | ✅
 | `.js` / `.jsx`            | JavaScript      | ✅ | ❌
 | `.ts` / `.tsx`            | TypeScript      | ✅ | ❌

--- a/emerge/files.py
+++ b/emerge/files.py
@@ -55,6 +55,7 @@ class LanguageExtension(Enum):
     OBJC = '.m'
     RUBY = '.rb'
     C_HEADER = '.h'
+    CPP_HEADER = '.hpp'
     PYTHON = '.py'
     GO = '.go'
 
@@ -109,7 +110,7 @@ class FileScanMapper:
             return PythonParser.parser_name()
         if file_extension == LanguageExtension.GO.value:
             return GoParser.parser_name()
-        if file_extension == LanguageExtension.C_HEADER.value:
+        if file_extension == LanguageExtension.C_HEADER.value or LanguageExtension.CPP_HEADER.value:
             if only_permit_languages:
                 if 'objc' in only_permit_languages:
                     return ObjCParser.parser_name()
@@ -138,13 +139,13 @@ class FileManager:
         if os.path.isdir(target_complete_path):
             try:
                 shutil.rmtree(target_complete_path)
-                
+
             except Exception as ex: # pylint: disable=broad-except
                 LOGGER.error(f'{ex}')
         try:
             shutil.copytree(origin_complete_path, target_complete_path)
             LOGGER.info_done("generated d3 web app for your browser")
-            
+
         except Exception as ex: # pylint: disable=broad-except
             LOGGER.error(f'{ex}')
 


### PR DESCRIPTION
By default, the C header parser discard .hpp files which is also used often in C++ project, more rarely in pure C project.
The parser is capable to parse them regarding of this.